### PR TITLE
feat: allow conditional disable of ingress

### DIFF
--- a/charts/cvat-helm/templates/ingress.yaml
+++ b/charts/cvat-helm/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.ingress.enabled }}
 {{ if .Values.ingress.clusterIssuer }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -61,5 +62,4 @@ spec:
 #    proxy_pass_header       X-CSRFToken;
 #    proxy_set_header        Host $http_host;
 #    proxy_pass_header       Set-Cookie;
-
-
+{{ end }}

--- a/charts/cvat-helm/values.yaml
+++ b/charts/cvat-helm/values.yaml
@@ -5,6 +5,7 @@ superUser:
   email: frank@kapernikov.com
 
 ingress:
+  enabled: true
   host: cvat.kube-public
   clusterIssuer: selfsigned-ca-issuer
   ingressClassName: nginx


### PR DESCRIPTION
Hello, by default you have enabled an nginx ingress. I use a traefik ingress with a complex configuration. 

This change would allow conditionally disabling the default ingress manifest from being generated.

Thanks!